### PR TITLE
Fix : Uncaught ReferenceError: Cannot access 'header' before initiali…

### DIFF
--- a/sdk.js
+++ b/sdk.js
@@ -288,11 +288,6 @@ function _installDesktopSsuper() {
   ssuper.classList.add(ssuperClosedClass);
   ssuper.classList.add(ssuperDesktopClass);
 
-  // set config width
-  if (getConfigValue('width')) {
-    header.style.setProperty('width', getConfigValue('width'));
-  }
-
   // set config height
   if (getConfigValue('height')) {
     ssuperOpenClass = createCSSClass({
@@ -314,6 +309,11 @@ function _installDesktopSsuper() {
           arrow.classList.replace(ssuperArrowDownClass, ssuperArrowUpClass);
       }
   });
+
+  // set config width
+  if (getConfigValue('width')) {
+    header.style.setProperty('width', getConfigValue('width'));
+  }
 
   // set config header image or color
   if (getConfigValue('backgroundImage')) {


### PR DESCRIPTION
Fix : Uncaught ReferenceError: Cannot access 'header' before initialization

Set config width need to be after header initialization.
